### PR TITLE
Makefile typo fix, remove "dev" target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,10 +71,6 @@ clean:
 filelist: all
 	@ls -1 deploy/*.y*ml
 
-.PHONE: resourcelist
+.PHONY: resourcelist
 resourcelist:
 	@echo $(RESOURCELIST)
-
-.PHONY: vardump
-vardump:
-	@echo $(SOURCE_CONFIGMAP_NAME)


### PR DESCRIPTION
`.PHONE` -> `.PHONY`, and remove a target that was used for development purposes.