### PR TITLE
Switch from nodeSelector to node affinity

### DIFF
--- a/hack/00-osd-managed-prometheus-exporter-ebs-iops-reporter.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-prometheus-exporter-ebs-iops-reporter.selectorsyncset.yaml.tmpl
@@ -8,7 +8,7 @@ objects:
   metadata:
     generation: 1
     labels:
-      managed.openshift.io/gitHash: e1d3218
+      managed.openshift.io/gitHash: e5f4d8d
       managed.openshift.io/osd: 'true'
     name: osd-managed-prometheus-exporter-ebs-iops-reporter
   spec:
@@ -187,6 +187,14 @@ objects:
               name: sre-ebs-iops-reporter
             name: sre-ebs-iops-reporter
           spec:
+            affinity:
+              nodeAffinity:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                - preference:
+                    matchExpressions:
+                    - key: node-role.kubernetes.io/infra
+                      operator: Exists
+                  weight: 1
             containers:
             - command:
               - /bin/sh
@@ -253,8 +261,6 @@ objects:
                 name: secrets
               - mountPath: /config
                 name: envfiles
-            nodeSelector:
-              node-role.kubernetes.io/infra: ''
             restartPolicy: Always
             serviceAccountName: sre-ebs-iops-reporter
             tolerations:

--- a/resources/040_deployment.yaml.tmpl
+++ b/resources/040_deployment.yaml.tmpl
@@ -27,8 +27,14 @@ spec:
           mountPath: /secrets
         - name: envfiles
           mountPath: /config
-      nodeSelector:
-        node-role.kubernetes.io/infra: ''
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/infra
+                operator: Exists
+            weight: 1
       tolerations:
         - effect: NoSchedule
           key: node-role.kubernetes.io/infra


### PR DESCRIPTION
* this ensures managed-prometheus-exporter-ebs-iops-reporter is also
deployed if no infra nodes exist