### PR TITLE
Add recently active flag to list metrics AWS API request

### DIFF
--- a/monitor/main.py
+++ b/monitor/main.py
@@ -68,9 +68,9 @@ def collect(aws):
     # List of volumes that we've actually had data back for the API
     seen_volumes = Set([])
 
-    # get all the volume IDs. Note, not all of these will necessarily have metrics
+    # get the volume IDs and filter the results to show only metrics that have had data points published in the past three hours (PT3H)
     volumePager = cw.get_paginator('list_metrics')
-    for p in volumePager.paginate(MetricName='BurstBalance', Namespace='AWS/EBS'):
+    for p in volumePager.paginate(MetricName='BurstBalance', Namespace='AWS/EBS', RecentlyActive='PT3H'):
         for v in p['Metrics']:
             volumes.add(v['Dimensions'][0]['Value'])
 
@@ -144,7 +144,7 @@ if __name__ == "__main__":
         description='Options for EBS IOPS Exporter')
     parser.add_argument('-p', '--aws-profile',
                         help='Name of AWS credentials profile to use', required=False, default="default")
-    parser.add_argument('-r', '--aws-region', help='AWS Regiom to use',
+    parser.add_argument('-r', '--aws-region', help='AWS Region to use',
                         required=False, default="us-east-1")
     args = vars(parser.parse_args())
 


### PR DESCRIPTION
## Description
The `main.py` script is making two requests to the AWS CLI: get metrics data, and list metrics. The list metrics API call [here](https://github.com/openshift/managed-prometheus-exporter-ebs-iops-reporter/blob/master/monitor/main.py#L72-L75) retrieves the ID of all of the volumes in a given region, which in some cases could be in the hundreds or thousands, due to CloudWatch retaining metrics for 15 months, as per the AWS docs:

>  Extended retention of metrics was launched on November 1, 2016, and enabled storage of all metrics for customers from the previous 14 days to 15 months

As the script executes every 5 minutes (288 times a day), the list metrics API request retrieves all of the EBS volumes for the past 15 months. In AWS regions with a high number of EBS volumes, each request returns a single metric for each volume, and CloudWatch charges [per metric](https://aws.amazon.com/cloudwatch/pricing). This can be costly in regions with hundreds or thousands of historical and current volumes.

## Changes Made
List metrics allows a [parameter](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_ListMetrics.html) called `RecentlyActive` to be passed in, with the only accepted value being `PT3H` (past 3 hours), as per the docs:

>  To filter the results to show only metrics that have had data points published in the past three hours, specify this parameter with a value of PT3H. This is the only valid value for this parameter

## Testing
I have executed the script manually against an AWS account with `10745` volumes, which comprises current `in-use` and historical volumes. 

Before the changes: `INFO:root: Have 272 ACTIVE_VOLUMES, seen 266 volumes, total volumes from list_metrics 10745`
After changes: `Have 278 ACTIVE_VOLUMES, seen 278 volumes, total volumes from list_metrics 404`