### PR TITLE
OSD-8637 Enable exporter to trust user-ca-bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,10 +51,11 @@ RESOURCELIST := servicemonitor/$(PREFIXED_NAME) service/$(PREFIXED_NAME) \
 	deploymentconfig/$(PREFIXED_NAME) secret/$(AWS_CREDENTIALS_SECRET_NAME) \
 	configmap/$(SOURCE_CONFIGMAP_NAME) rolebinding/$(PREFIXED_NAME) \
 	serviceaccount/$(SERVICEACCOUNT_NAME) clusterrole/sre-allow-read-cluster-setup \
-	CredentialsRequest/$(AWS_CREDENTIALS_SECRET_NAME)
+	CredentialsRequest/$(AWS_CREDENTIALS_SECRET_NAME) \
+	configmap/$(PREFIXED_NAME)-trusted-ca-bundle
 
 
-all: deploy/010_serviceaccount-rolebinding.yaml deploy/020-awscredentials-request.yaml deploy/025_sourcecode.yaml deploy/040_deployment.yaml deploy/050_service.yaml deploy/060_servicemonitor.yaml generate-syncset
+all: deploy/010_serviceaccount-rolebinding.yaml deploy/020-awscredentials-request.yaml deploy/025_sourcecode.yaml deploy/030_ca-configmap.yaml deploy/040_deployment.yaml deploy/050_service.yaml deploy/060_servicemonitor.yaml generate-syncset
 
 deploy/020-awscredentials-request.yaml: resources/020-awscredentials-request.yaml.tmpl
 	@$(call generate_file,020-awscredentials-request)
@@ -67,6 +68,9 @@ deploy/025_sourcecode.yaml: $(SOURCEFILES)
 		files="--from-file=$$sfile $$files" ; \
 	done ; \
 	oc -n openshift-monitoring create configmap $(SOURCE_CONFIGMAP_NAME) --dry-run=client -o yaml $$files 1> deploy/025_sourcecode.yaml
+
+deploy/030_ca-configmap.yaml: resources/030_ca-configmap.yaml.tmpl
+	@$(call generate_file,030_ca-configmap)
 
 deploy/040_deployment.yaml: resources/040_deployment.yaml.tmpl
 	@$(call generate_file,040_deployment)

--- a/hack/00-osd-managed-prometheus-exporter-ebs-iops-reporter.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-prometheus-exporter-ebs-iops-reporter.selectorsyncset.yaml.tmpl
@@ -8,7 +8,7 @@ objects:
   metadata:
     generation: 1
     labels:
-      managed.openshift.io/gitHash: b7d4643
+      managed.openshift.io/gitHash: b30db33
       managed.openshift.io/osd: 'true'
     name: osd-managed-prometheus-exporter-ebs-iops-reporter
   spec:
@@ -81,13 +81,13 @@ objects:
           namespace: openshift-monitoring
     - apiVersion: v1
       data:
-        main.py: "#!/usr/bin/env python\n\nimport argparse\nimport boto3\nimport botocore\n\
-          import datetime\nimport logging\nimport os\nimport re\nimport time\n\nfrom\
-          \ prometheus_client import start_http_server, Gauge, Counter\n\nEBS_IOPS\
-          \ = Gauge(\"ebs_iops_credits\",\n                 \"Percent of burstable\
-          \ IOPS credit available\", labelnames=['vol_id'])\n\n# A list (implemented\
-          \ as a Set) of all active volumes.\nACTIVE_VOLUMES = set([])\n\n# Period\
-          \ in minutes from cloudwatch to request\n# See https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_GetMetricData.html\n\
+        main.py: "#!/usr/bin/env python\n\n\nimport argparse\nimport boto3\nimport\
+          \ botocore\nimport datetime\nimport logging\nimport os\nimport re\nimport\
+          \ time\n\nfrom prometheus_client import start_http_server, Gauge, Counter\n\
+          \nEBS_IOPS = Gauge(\"ebs_iops_credits\",\n                 \"Percent of\
+          \ burstable IOPS credit available\", labelnames=['vol_id'])\n\n# A list\
+          \ (implemented as a Set) of all active volumes.\nACTIVE_VOLUMES = set([])\n\
+          \n# Period in minutes from cloudwatch to request\n# See https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_GetMetricData.html\n\
           CLOUDWATCH_PERIOD = 5\n\nBOTO_ERRS = Counter('boto_exceptions', 'The total\
           \ number of boto exceptions')\n\n\ndef chunks(l, n):\n    \"\"\"\n    Chunks\
           \ up an array +l+ into chunks of +n+ size\n    Based on https://stackoverflow.com/questions/312443/how-do-you-split-a-list-into-evenly-sized-chunks\n\
@@ -182,6 +182,13 @@ objects:
         creationTimestamp: null
         name: sre-ebs-iops-reporter-code
         namespace: openshift-monitoring
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        labels:
+          config.openshift.io/inject-trusted-cabundle: 'true'
+        name: sre-ebs-iops-reporter-trusted-ca-bundle
+        namespace: openshift-monitoring
     - apiVersion: apps.openshift.io/v1
       kind: DeploymentConfig
       metadata:
@@ -251,6 +258,9 @@ objects:
               - mountPath: /secrets
                 name: secrets
                 readOnly: true
+              - mountPath: /etc/pki/ca-trust/extracted/pem
+                name: trusted-ca-bundle
+                readOnly: true
               workingDir: /monitor
             dnsPolicy: ClusterFirst
             initContainers:
@@ -276,6 +286,9 @@ objects:
                 name: secrets
               - mountPath: /config
                 name: envfiles
+              - mountPath: /etc/pki/ca-trust/extracted/pem
+                name: trusted-ca-bundle
+                readOnly: true
             restartPolicy: Always
             serviceAccountName: sre-ebs-iops-reporter
             tolerations:
@@ -293,6 +306,13 @@ objects:
             - configMap:
                 name: sre-ebs-iops-reporter-code
               name: monitor-volume
+            - configMap:
+                defaultMode: 420
+                items:
+                - key: ca-bundle.crt
+                  path: tls-ca-bundle.pem
+                name: sre-ebs-iops-reporter-trusted-ca-bundle
+              name: trusted-ca-bundle
         triggers:
         - type: ConfigChange
     - apiVersion: v1

--- a/resources/030_ca-configmap.yaml.tmpl
+++ b/resources/030_ca-configmap.yaml.tmpl
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: openshift-monitoring
+  name: $PREFIXED_NAME-trusted-ca-bundle
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"

--- a/resources/040_deployment.yaml.tmpl
+++ b/resources/040_deployment.yaml.tmpl
@@ -27,6 +27,9 @@ spec:
           mountPath: /secrets
         - name: envfiles
           mountPath: /config
+        - mountPath: /etc/pki/ca-trust/extracted/pem
+          name: trusted-ca-bundle
+          readOnly: true
       affinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -79,6 +82,9 @@ spec:
         - name: secrets
           mountPath: /secrets
           readOnly: true
+        - mountPath: /etc/pki/ca-trust/extracted/pem
+          name: trusted-ca-bundle
+          readOnly: true
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       serviceAccountName: $SERVICEACCOUNT_NAME
@@ -93,6 +99,13 @@ spec:
       - name: monitor-volume
         configMap:
           name: $SOURCE_CONFIGMAP_NAME
+      - name: trusted-ca-bundle
+        configMap:
+          defaultMode: 420
+          items:
+            - key: ca-bundle.crt
+              path: tls-ca-bundle.pem
+          name: $PREFIXED_NAME-trusted-ca-bundle
   triggers:
   - type: ConfigChange
   strategy:


### PR DESCRIPTION
### What type of PR is this?

Feature

### What this PR does / why we need it?

This PR adds a new `trusted-ca-bundle` ConfigMap for the exporter which will contain the system CA certs used to authenticate HTTPS connections. [0]

The ConfigMap contains the `config.openshift.io/inject-trusted-cabundle` label so that the user-supplied CA bundle is injected into it.

The ConfigMap is mounted into the container in the `/etc/pki/ca-trust/extracted/pem` location such that no other work is required to have the application use these CA for verifying server cert authenticity.

This is an approach which aligns with other cluster operators including the console and insights operators. 

[0] https://docs.openshift.com/container-platform/4.9/networking/configuring-a-custom-pki.html

### Which Jira/Github issue(s) this PR fixes?

[OSD-8637](https://issues.redhat.com/browse/OSD-8637)

### Special notes for your reviewer:

This change has been successfully tested on a cluster using a transparent forward proxy to ensure that it could successfully communicate to `*.amazonaws.com`.

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [X] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR
