### PR TITLE
[OSD-11452] Add files to run linting with tox.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,3 +103,7 @@ resourcelist:
 git-commit-sss-template:
 	git add ${SELECTOR_SYNC_SET_DESTINATION}
 	git commit -m "Updated selectorsynceset template added"
+
+.PHONY: lint
+lint:
+	tox

--- a/hack/app_sre_pr_check.sh
+++ b/hack/app_sre_pr_check.sh
@@ -2,5 +2,13 @@
 
 set -exv
 
+python3 -m venv .venv
+source .venv/bin/activate
+
+pip install tox
+tox
+
+deactivate
+
 # script needs to pass for app-sre workflow 
 exit 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Red Hat Openshift SRE"]
 license = "apache"
 
 [tool.poetry.dependencies]
-python = ">3.8"
+python = ">3.6"
 
 [tool.poetry.dev-dependencies]
 bandit = "^1.7.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.poetry]
+name = "monitor"
+version = "0.1.0"
+description = "Managed Prometheus Exporter to report EBS IOPS"
+authors = ["Red Hat Openshift SRE"]
+license = "apache"
+
+[tool.poetry.dependencies]
+python = ">3.8"
+
+[tool.poetry.dev-dependencies]
+bandit = "^1.7.4"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+isolated_build = True
+envlist = py39,py310
+
+[tox:.package]
+basepython = python3
+
+[testenv]
+deps =
+     bandit==1.7.4
+commands =
+     bandit **/*.py

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
 isolated_build = True
-envlist = py39,py310
+envlist = py36
 
 [tox:.package]
 basepython = python3
 
 [testenv]
 deps =
-     bandit==1.7.4
+     bandit==1.6.2
 commands =
      bandit **/*.py


### PR DESCRIPTION
As gosec is not useful to add to a python project for security linting, this PR adds the [bandit](https://pypi.org/project/bandit/) linter to the project to run via `tox`.

- Added a pyproject file
- Added a make target for lint
- Added the basic tox file that runs bandit for security linting