### PR TITLE
fix: disable deployment on STS clusters

### DIFF
--- a/hack/00-osd-managed-prometheus-exporter-ebs-iops-reporter.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-prometheus-exporter-ebs-iops-reporter.selectorsyncset.yaml.tmpl
@@ -16,6 +16,11 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
         hive.openshift.io/cluster-platform: aws
+      matchExpressions:
+      - key: api.openshift.com/sts
+        operator: NotIn
+        values:
+        - "true"
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1


### PR DESCRIPTION
The exporter does not currently support STS deployments. This change will only deploy the exporter on non sts clusters